### PR TITLE
Remove deprecated package: flycheck-mix

### DIFF
--- a/lisp/init-elixir.el
+++ b/lisp/init-elixir.el
@@ -39,10 +39,6 @@
     (add-hook 'elixir-mode-hook 'alchemist-mode)
     (add-hook 'elixir-mode-hook 'alchemist-phoenix-mode))
 
-  (use-package flycheck-mix
-    :after flycheck
-    :init (flycheck-mix-setup))
-
   (use-package flycheck-credo
     :after flycheck
     :init (flycheck-credo-setup)))


### PR DESCRIPTION
The flycheck-mix package [has been removed from Melpa](https://github.com/tomekowal/flycheck-mix), causing an error when editing elixir files (while trying to install that package).